### PR TITLE
Add hot restart support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ This extension also installs an MCP server (`flutter_launcher`) that provides to
 
 - `launch_app`: Launches a Flutter application on a specified device.
 - `stop_app`: Stops a running Flutter application.
+- `hot_restart`: Performs a hot restart on a running Flutter application, resetting the app state while maintaining the current session.
 - `list_devices`: Lists all available devices that can run Flutter applications.
 - `get_app_logs`: Retrieves the logs from a running Flutter application.
 - `list_running_apps`: Lists all Flutter applications currently running that were started by this extension.

--- a/flutter_launcher_mcp/README.md
+++ b/flutter_launcher_mcp/README.md
@@ -89,6 +89,40 @@ Launches a Flutter application with specified arguments and returns its DTD URI 
   }
   ```
 
+#### `hot_restart`
+
+Performs a hot restart on a running Flutter application. This restarts the app while maintaining the current session.
+
+- **Input Schema:**
+
+  ```json
+  {
+    "type": "object",
+    "properties": {
+      "pid": {
+        "type": "integer",
+        "description": "The process ID of the flutter run process to hot restart."
+      }
+    },
+    "required": ["pid"]
+  }
+  ```
+
+- **Output Schema:**
+
+  ```json
+  {
+    "type": "object",
+    "properties": {
+      "success": {
+        "type": "boolean",
+        "description": "Whether the hot restart was successful."
+      }
+    },
+    "required": ["success"]
+  }
+  ```
+
 #### `stop_app`
 
 Kills a running Flutter process started by the `launch_app` tool.

--- a/flutter_launcher_mcp/test/sdk_test.dart
+++ b/flutter_launcher_mcp/test/sdk_test.dart
@@ -245,6 +245,9 @@ class MockProcess implements Process {
 
   bool killed = false;
 
+  @override
+  late final IOSink stdin = _MockIOSink();
+
   MockProcess({
     required this.stdout,
     required this.stderr,
@@ -268,7 +271,61 @@ class MockProcess implements Process {
     }
     return true;
   }
+}
+
+class _MockIOSink implements IOSink {
+  final List<String> writtenLines = [];
+  bool _closed = false;
 
   @override
-  late final IOSink stdin = throw UnimplementedError();
+  Encoding encoding = utf8;
+
+  @override
+  void add(List<int> data) {
+    if (_closed) throw StateError('IOSink is closed');
+  }
+
+  @override
+  void write(Object? object) {
+    if (_closed) throw StateError('IOSink is closed');
+  }
+
+  @override
+  void writeln([Object? object = '']) {
+    if (_closed) throw StateError('IOSink is closed');
+    writtenLines.add(object.toString());
+  }
+
+  @override
+  Future<void> flush() async {
+    if (_closed) throw StateError('IOSink is closed');
+  }
+
+  @override
+  Future<void> close() async {
+    _closed = true;
+  }
+
+  @override
+  void addError(Object error, [StackTrace? stackTrace]) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future addStream(Stream<List<int>> stream) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future get done => Future.value();
+
+  @override
+  void writeAll(Iterable objects, [String separator = '']) {
+    throw UnimplementedError();
+  }
+
+  @override
+  void writeCharCode(int charCode) {
+    throw UnimplementedError();
+  }
 }


### PR DESCRIPTION
## Summary

Adds `hot_restart` tool to the flutter_launcher MCP server. Works the same as pressing 'R' in the terminal during `flutter run` - restarts the app without killing the debug session.

## Changes

- New `hot_restart` tool that sends 'R' command to process stdin
- Fixed test mock stdin (was throwing UnimplementedError)
- Added tests for success and error cases
- Updated docs

## Usage

```javascript
hot_restart({ pid: 12345 })
```

Returns success/failure status.