### PR TITLE
Emphasize installation is a terminal command

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You can manage the extension with the following commands:
   gemini extensions update flutter
   ```
 
-- Uninstall the extension
+- Uninstall the extension.
 
   ```bash
   gemini extensions uninstall flutter


### PR DESCRIPTION
Add the word "terminal" before "command" to disambiguate against a command that might be entered after launching gemini-cli.

Split the install and uninstall steps into separate code blocks so that the UI copy button which copies the entire block is more useful. Nest the code blocks in a list and move the comments to list text.